### PR TITLE
readme typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 gets colume  
 `volume X`
 sets volume to X  
-`version'
+`version`
 gets version  
 `setversion`
-setss version based on fbdriver  
+sets version based on fbdriver  
 `setversion X`
 sets version to X  
-BB 2.5/2 use 1 
+BB 2.5/2 use 1  
 BB 3/35 PG use 3


### PR DESCRIPTION
fixed a code block that was closed with a singlequote instead of a backtick, "setss" => "set", and line breakes.