### PR TITLE
Set up CI build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,34 @@
+# based on https://github.com/MiyooCFW/gmenunx/blob/master/.github/workflows/c-cpp.yml
+name: CI Build
+
+on: [push, pull_request]
+
+jobs:   
+  build-modern:
+    name: miyooctl for MiyooCFW 1.4+ (musl libc)
+    runs-on: ubuntu-20.04
+    container:
+      image: nfriedly/miyoo-toolchain:latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: build
+      run: make
+    - uses: actions/upload-artifact@v2
+      with:
+        name: miyooctl binary
+        path: miyooctl
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
+  build-legacy:
+    name: miyooctl legacy build for Miyoo <=1.3.3 (uClibc)
+    runs-on: ubuntu-20.04
+    container:
+      image: nfriedly/miyoo-toolchain:steward
+    steps:
+    - uses: actions/checkout@v2
+    - name: build
+      run: make
+    - uses: actions/upload-artifact@v2
+      with:
+        name: miyooctl legacy binary
+        path: miyooctl
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ PROG ?= miyooctl
 
 #PREFIX ?= arm-linux-
 #PREFIX ?= arm-linux-gnueabi-
-PREFIX ?= arm-buildroot-linux-musleabi-
+#PREFIX ?= arm-buildroot-linux-musleabi-
+PREFIX ?= /opt/miyoo/bin/arm-linux-
 
 EXTRAFLAGS ?= -Wall -static
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SOURCES ?= main.c
 PROG ?= miyooctl
 
-#PREFIX ?= arm-linux-
+PREFIX ?= arm-linux-
 #PREFIX ?= arm-linux-gnueabi-
-PREFIX ?= arm-buildroot-linux-musleabi-
+#PREFIX ?= arm-buildroot-linux-musleabi-
 
 EXTRAFLAGS ?= -Wall -static
 

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ PROG ?= miyooctl
 
 #PREFIX ?= arm-linux-
 #PREFIX ?= arm-linux-gnueabi-
-#PREFIX ?= arm-buildroot-linux-musleabi-
-PREFIX ?= /opt/miyoo/bin/arm-linux-
+PREFIX ?= arm-buildroot-linux-musleabi-
 
 EXTRAFLAGS ?= -Wall -static
 


### PR DESCRIPTION
This is similar to the setup for GMemuNX - build on both the musll and uClibc toolchains, save the binary from each as an artifact.

I tweaked the makefile to use the right path for the crosss-compile toolchains. Hopefully that won't cause trouble for other things. I suppose we could put it into env variables (I think the older toolchain's docker actually has a few set, so I could probably copy those over if you want.)